### PR TITLE
fix RPC for AWS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Known Limitations
 * Using the `pymq` singleton in multiprocessing scenarios may not work as expected because the module holds a Thread in
   a global variable. A workaround is to re-start the bus by calling `shutdown()` and `init()` in the forked Process.
 * IPC provider only works for Linux
+* Multi-RPC does not work for the AWS provider
+* AWS provider cannot automatically delete all queues and topics.
 
 Background
 ----------

--- a/pymq/core.py
+++ b/pymq/core.py
@@ -87,7 +87,7 @@ class EventBus(abc.ABC):
     def close(self):
         raise NotImplementedError
 
-    def publish(self, event, channel=None):
+    def publish(self, event, channel=None) -> Optional[int]:
         raise NotImplementedError
 
     def subscribe(self, callback: Callable, channel=None, pattern=False):
@@ -99,7 +99,7 @@ class EventBus(abc.ABC):
     def queue(self, name: str) -> Queue:
         raise NotImplementedError
 
-    def topic(self, name: str, pattern: bool = False):
+    def topic(self, name: str, pattern: bool = False) -> Topic:
         raise NotImplementedError
 
     def stub(self, fn, timeout=None, multi=False) -> StubMethod:

--- a/tests/provider/test_aws.py
+++ b/tests/provider/test_aws.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pymq.provider.aws import encode_topic_name, validate_topic_name
+from pymq.provider.aws import decode_topic_name, encode_topic_name, validate_topic_name
 
 
 def test_validate_topic_name():
@@ -14,6 +14,9 @@ def test_validate_topic_name():
         validate_topic_name("#!$")
 
     with pytest.raises(ValueError):
+        validate_topic_name("foo.<locals>")
+
+    with pytest.raises(ValueError):
         validate_topic_name("a" * 257)
 
     validate_topic_name("foobar")
@@ -22,6 +25,24 @@ def test_validate_topic_name():
 
 
 def test_encode_topic_name():
+    validate_topic_name(encode_topic_name("foo"))
+    validate_topic_name(encode_topic_name("foo/bar"))
+    validate_topic_name(encode_topic_name("foo/*"))
     validate_topic_name(encode_topic_name("__main__.foobar"))
     validate_topic_name(encode_topic_name("__main__.foobar:Event"))
-    validate_topic_name(encode_topic_name("foo/bar"))
+    validate_topic_name(encode_topic_name("tests.remote.<locals>.remote_test_fn"))
+
+
+def test_encode_decode_topic_name():
+    def test(name):
+        assert decode_topic_name(encode_topic_name(name)) == name
+
+    test("foo")
+    test("foo/bar")
+    test("foo/*")
+    test("__main__.foobar")
+    test("__main__.foobar:Event")
+    test("tests.remote.<locals>.remote_test_fn")
+
+    with pytest.raises(AssertionError):
+        test("._DOT_.")  # limitation of the encoding

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -191,10 +191,8 @@ class TestPubSub:
         assert "foobar" == called.payload.name
         assert 42 == called.payload.value
 
+    @pytest.mark.xfail_provider("init_ipc", "init_simple", "init_aws")
     def test_publish_pattern(self, bus):
-        if bus.type in [IpcEventBus, SimpleEventBus, AwsEventBus]:
-            pytest.xfail(reason="pattern publish not implemented for bus type")
-
         invocations = queue.Queue()
 
         @pymq.subscriber("channel/*", True)

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -80,7 +80,6 @@ class RpcHolder:
 
 
 # noinspection PyUnresolvedReferences
-@pytest.mark.xfail_provider("init_aws")
 class TestRpc:
     @pytest.mark.timeout(60)
     def test_assert_bus(self, bus):
@@ -279,7 +278,7 @@ class TestRpc:
         logger.debug("calling stub for myfn")
         assert 2 == stub()
 
-    @pytest.mark.timeout(5)
+    @pytest.mark.timeout(60)
     def test_expose_before_init(self, pymq_init):
         def remote_fn():
             return "hello"


### PR DESCRIPTION
simple change in the `DefaultStubMethod` to deal with scenarios where `multi=False` and `publish` returning `None`. We now make the implicit assumption that there is only one subscriber (=remote object) if `None` is returned, which fixes the generalization, but may lead to abandoned queues and items in the queues if another remote object writes into the response queue.

also adds some minor changes to make it work and fix the RPC tests for the AWS provider.